### PR TITLE
Fix badge links in README for PyPI version and Python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # splurge-tabular
-[![PyPI version](https://badge.fury.io/py/splurge-dsv.svg)](https://pypi.org/project/splurge-dsv/)
-[![Python versions](https://img.shields.io/pypi/pyversions/splurge-tabular.svg)](https://pypi.org/project/splurge-dsv/)
+[![PyPI version](https://badge.fury.io/py/splurge-tabular.svg)](https://pypi.org/project/splurge-tabular/)
+[![Python versions](https://img.shields.io/pypi/pyversions/splurge-tabular.svg)](https://pypi.org/project/splurge-tabular/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
 [![CI](https://github.com/jim-schilling/splurge-tabular/actions/workflows/ci-quick-test.yml/badge.svg)](https://github.com/jim-schilling/splurge-tabular/actions/workflows/ci-quick-test.yml)


### PR DESCRIPTION
This pull request updates the badges in the `README.md` to correctly reference the `splurge-tabular` package instead of `splurge-dsv`. This ensures that the displayed PyPI version and supported Python versions are accurate for this repository.